### PR TITLE
Implement file server to serve models, create helper endpoints

### DIFF
--- a/server/controllers/downloadController.js
+++ b/server/controllers/downloadController.js
@@ -37,3 +37,13 @@ exports.downloadS3 = (req, res) => {
     });
     fileStream.pipe(res);
 };
+
+exports.hasModel = (req, res) => {
+    const { modelName } = req.query;
+    // Check if the model exists
+    if (fs.existsSync(`models/${modelName}`)) {
+        res.sendStatus(200);
+    } else {
+        res.status(404).send('Model not found!');
+    }
+};

--- a/server/controllers/downloadController.js
+++ b/server/controllers/downloadController.js
@@ -38,6 +38,13 @@ exports.downloadS3 = (req, res) => {
     fileStream.pipe(res);
 };
 
+exports.listModels = async (req, res) => {
+    const files = (await fs.promises.readdir('models', { withFileTypes: true }))
+        .filter((entry) => entry.isDirectory())
+        .map((dir) => dir.name);
+    res.json(files);
+};
+
 exports.hasModel = (req, res) => {
     const { modelName } = req.query;
     // Check if the model exists

--- a/server/routes/downloadRoutes.js
+++ b/server/routes/downloadRoutes.js
@@ -8,4 +8,6 @@ router.get('/', downloadController.download);
 
 router.get('/s3', downloadController.downloadS3);
 
+router.get('/hasModel', downloadController.hasModel);
+
 module.exports = router;

--- a/server/routes/downloadRoutes.js
+++ b/server/routes/downloadRoutes.js
@@ -8,6 +8,8 @@ router.get('/', downloadController.download);
 
 router.get('/s3', downloadController.downloadS3);
 
+router.get('/listModels', downloadController.listModels);
+
 router.get('/hasModel', downloadController.hasModel);
 
 module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -11,4 +11,6 @@ app.use('/download', downloadRoute);
 
 app.use('/upload', uploadRoute);
 
+app.use('/models', express.static('models'));
+
 module.exports = app;


### PR DESCRIPTION
Resolves #27

Created the `/download/listModels/` and `/download/hasModel` endpoints to list the models available and determine if a model is on the server.

Hosting the model .json spec and associated weights files as static content from the `/models` folder.